### PR TITLE
fix: returning integer frame numbers when using rates like 30df/29.97

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export class Timecode implements ITimecodeObject {
     count += input.seconds * framerate;
     count += input.frames;
 
-    return count;
+    return Math.round(count);
   }
 
   public hours = 0;
@@ -126,7 +126,7 @@ export class Timecode implements ITimecodeObject {
     const fps = this.options.framerate;
 
     return {
-      frames: count % fps,
+      frames: Math.round(count % fps),
       hours: Math.floor(count / (fps * 60 * 60)) % 24,
       minutes: Math.floor(count / (fps * 60)) % 60,
       seconds: Math.floor(count / fps) % 60


### PR DESCRIPTION
Round frame numbers to full integers to avoid output of floating point numbers when using frame-rates like 29.97.
As a fix for https://github.com/tim-smart/mtc/issues/1